### PR TITLE
fix: use current available words instead of setting

### DIFF
--- a/src/components/greetingWrapper/GreetingWrapper.js
+++ b/src/components/greetingWrapper/GreetingWrapper.js
@@ -4,16 +4,17 @@ import Greeting from '../greeting/Greeting';
 import ContinueTrainingBlock from '../continueTrainingBlock/ContinueTrainingBlock';
 import './GreetingWrapper.scss';
 import settingsController from '../../controllers/SettingsController';
-import settingSubject from '../../utils/observers/SettingSubject';
 import statisticsSubject from '../../utils/observers/StatisticsSubject';
 import statisticsController from '../../controllers/StatisticsController';
+import wordQueueSubject from '../../utils/observers/WordQueueSubject';
+import wordController from '../../controllers/WordConrtoller';
 
 const GreetingWrapper = () => {
   const [cardsCount, setCardCount] = useState(settingsController.getCardsCount());
   const [passedCount, setPassedCount] = useState(statisticsController.getPassedCount());
 
   const updateCardCount = () => {
-    setCardCount(settingsController.getCardsCount());
+    setCardCount(wordController.getWordsCount());
   };
 
   const updatePassedCount = () => {
@@ -21,11 +22,11 @@ const GreetingWrapper = () => {
   };
 
   useEffect(() => {
-    settingSubject.subscribe(updateCardCount);
+    wordQueueSubject.subscribe(updateCardCount);
     statisticsSubject.subscribe(updatePassedCount);
 
     return () => {
-      settingSubject.unsubscribe(updateCardCount);
+      wordQueueSubject.unsubscribe(updateCardCount);
       statisticsSubject.unsubscribe(updatePassedCount);
     };
   }, []);

--- a/src/controllers/WordConrtoller.js
+++ b/src/controllers/WordConrtoller.js
@@ -22,6 +22,13 @@ class WordController {
 
   getQueue = () => this.model.wordQueue;
 
+  getWordsCount = () => {
+    if (!this.model.wordQueue) {
+      return 0;
+    }
+    return this.model.wordQueue.getWords().length;
+  }
+
   endQueue = async () => this.endQueue();
 
   reset = () => {


### PR DESCRIPTION
Previously we have Greetings dependent on settings. But that causes a wrong behavior when there is not enough user or new words  (in the beginning or in the end of learning). Right now greetings container is updated using the currently available words.