### PR TITLE
fix: when there is a word for education force to have train

### DIFF
--- a/src/utils/spacedRepetition/WordQueue.js
+++ b/src/utils/spacedRepetition/WordQueue.js
@@ -155,7 +155,14 @@ export default class WordQueue {
     if (repetitionTime) {
       queue.push({ word, isEducation: false, nextTime: repetitionTime });
     }
-    educationTimes.forEach((time) => queue.push({ word, isEducation: true, nextTime: time }));
+    educationTimes.forEach((time) => {
+      if (!repetitionTime) {
+        queue.push({ word, isEducation: true, nextTime: time - 1000 * Math.random(20) });
+        queue.push({ word, isEducation: false, nextTime: time + 1000 * Math.random(20) });
+      } else {
+        queue.push({ word, isEducation: true, nextTime: time });
+      }
+    });
   }
 
   getTodayWords = () => this.words.map((word) => word.definition.wordId);


### PR DESCRIPTION
there are 2 flows of repetition - Education & Train. When it is education it shows already answered word. When it is training - it asks a user to insert a word. 

before: Train not depends on education
now: if there is an Education for today it forces to have at least one Training card too.